### PR TITLE
Add Gauss-Bonnet triangle sum example and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.DS_Store
+*.egg-info/
+.pytest_cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ryan K. Stephens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,115 @@
-# Adaptive-PI
+# adaptive-pi-geometry
+
+A lightweight Python library + reference spec for **Adaptive \u03c0 (\u03c0\u2090)** geometry: a unifying framework that reduces to Euclidean geometry when curvature \u2192 0 and extends gracefully to curved/inhomogeneous settings using first\u2011order Gauss\u2013Bonnet corrections.
+
+---
+
+## Why this repo exists
+
+* **Goal:** Provide clean, testable primitives for \u03c0\u2090 so others can *use* and *verify* the framework on classic Euclidean (IMO-style) problems, then turn the \u201ccurvature dial\u201d to see controlled deviations.
+* **Philosophy:** Everything here must (1) recover standard Euclidean results when `K(x,y) = 0`, and (2) make curvature effects explicit and composable.
+
+---
+
+## Repository structure
+
+```
+adaptive-pi-geometry/
+├─ README.md
+├─ LICENSE
+├─ pyproject.toml
+├─ .gitignore
+├─ docs/
+│  ├─ SPEC.md
+│  └─ IMO-translation-guide.md
+├─ src/
+│  └─ pi_a/
+│     ├─ __init__.py
+│     ├─ core.py            # \u03c0\u2090 primitives: angle sum, cyclicity, flux integrals
+│     ├─ geometry.py        # basic constructions & helpers
+│     └─ models.py          # curvature fields (K) + convenience wrappers
+├─ examples/
+│  ├─ example1_orthocenter_reflection_pi_a.py
+│  └─ example2_ceva_trig_pia.py
+└─ tests/
+   ├─ test_flat_limit.py
+   ├─ test_cyclicity_balance.py
+   └─ test_ceva_trig_pia.py
+```
+
+---
+
+## Quickstart
+
+```bash
+# 1) clone your new repo (after you push it), then:
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -e .
+pytest -q
+```
+
+```python
+# Minimal usage
+from pi_a.core import triangle_angle_sum_pia, is_pia_cyclic
+from pi_a.models import ConstantCurvature
+
+A, B, C = (0.0, 0.0), (1.0, 0.0), (0.2, 0.8)
+K = ConstantCurvature(0.0)   # Flat: \u03c0\u2090 \u2192 \u03c0
+S = triangle_angle_sum_pia(A,B,C, K)
+print(S)  # ~ math.pi
+
+# Check \u03c0\u2090-cyclicity for quadruple (recovers Euclidean cyclic test when K=0)
+D = (0.9, 0.2)
+print(is_pia_cyclic(A,B,C,D, K))
+```
+
+---
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+---
+
+## Design guarantees
+
+* **Flat\u2011limit exactness:** With `K(x,y) \u2261 0`, all \u03c0\u2090 primitives reduce to classical Euclidean identities.
+* **First\u2011order correctness:** For small/slowly\u2011varying curvature, results match Gauss\u2013Bonnet style corrections with integrated curvature flux through polygons/sectors.
+* **Composability:** Angle sums, cyclicity, Ceva/Menelaus (trig form) expose the curvature terms explicitly so you can budget/trace deviations.
+
+---
+
+## Files
+
+... (See individual files for details).
+
+---
+
+## Roadmap
+
+* **v0.2**: Explicit \u03c0\u2090 Ceva/Menelaus numerics (build sector/flux terms for split points).
+* **v0.3**: Inversion and power\u2011of\u2011a\u2011point under \u03c0\u2090; adaptive circumcurves.
+* **v0.4**: Geodesic circle model & better sector integration (adaptive radius profile).
+* **v0.5**: Symbolic layer (SymPy) for first\u2011order expansions and human\u2011readable proofs.
+
+---
+
+## How to publish
+
+```bash
+git init
+git add .
+git commit -m "init: adaptive-pi-geometry v0.1 bootstrap"
+git branch -M main
+git remote add origin git@github.com:RDM3DC/adaptive-pi-geometry.git
+git push -u origin main
+```
+
+---
+
+## Citation (placeholder)
+
+> Stephens, R.K. (2025). *Adaptive \u03c0 (\u03c0\u2090) Geometry: Flat\u2011Limit Exactness and First\u2011Order Curvature Corrections.* RDM3DC Labs. Version 0.1.

--- a/docs/IMO-translation-guide.md
+++ b/docs/IMO-translation-guide.md
@@ -1,0 +1,11 @@
+# Translating IMO Geometry to \u03c0\u2090
+
+This guide shows how to port classic Euclidean arguments to \u03c0\u2090.
+
+1) **Replace** any use of \u201c\u03c0\u201d from straight/half-turn closures with **\u03c0\u2090(region)** = \u03c0 + \u03a6_region.
+2) **Angle-chasing:** carry a flux budget. When two inscribed angles are compared, add the sector-flux difference.
+3) **Right angles:** remain right in the flat limit; away from flatness, use local orthogonality modulo O(\u03a6) corrections.
+4) **Ceva/Menelaus:** use trig forms and attach exp(\u03b5\u00b7\u039e) correction, which vanishes when K\u22610.
+5) **Inversion/circle power:** approximate by \u03c0\u2090-circles (geodesic circles). To first order, radii/centers perturb; equal-power relations include small flux terms but preserve structure.
+
+Worked examples are in `examples/`.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,0 +1,32 @@
+# \u03c0\u2090 Geometry \u2014 Reference Spec (v0.1)
+
+## 1. Principle
+Let K(x,y) denote Gaussian curvature (or an effective curvature density) over a planar domain D. For any geodesic polygon P with interior D_P,
+
+**Triangle angle sum (first order):**
+S_\u0394 := A + B + C = \u03c0 + \u03a6_\u0394,   where  \u03a6_\u0394 := \u222c\u222c_{D_\u0394} K dA.
+
+**m-gon angle sum (first order):**
+S_m = (m-2)\u03c0 + \u03a6_P, with \u03a6_P := \u222c\u222c_{D_P} K dA.
+
+**Cyclicity (adaptive inscribed-angle):**
+In Euclidean space, A,B,C,X are concyclic iff \u2220ABX = \u2220ACX. In \u03c0\u2090, we model the inscribed angle as picking up a sector flux correction:
+
+\u2220ABX - \u2220ACX \u2248 \u00bd(\u03a6_{ABX}^\u25D6 \u2212 \u03a6_{ACX}^\u25D6).
+
+A,B,C,X are **\u03c0\u2090-cyclic** if the difference above vanishes to first order (sectors balance), recovering the Euclidean criterion when K\u22610.
+
+**Ceva (trig form, \u03c0\u2090):**
+For cevians AD, BE, CF concurrent in triangle ABC,
+
+( sin(\u00c2_D) sin( \u0042\u0302_E ) sin( \u00c7_F ) ) / ( sin(\u00c2'_D) sin( \u0042\u0302'_E ) sin( \u00c7'_F ) ) = 1 \u00b7 exp(\u03b5\u00b7\u039e) ,
+
+where the numerator/denominator use the appropriate interior angles at each split and \u039e is a linear functional of local flux imbalances (vanishes in K\u22610). For small curvature, exp(\u03b5\u00b7\u039e) \u2248 1 + \u03b5\u00b7\u039e.
+
+This spec fixes signs and orientations in code; see `core.py` for definitions.
+
+## 2. Flat limit
+All formulas reduce to Euclidean identities when \u03a6 \u2261 0.
+
+## 3. Validity
+First-order in |K|\u00b7Area and for slowly varying K across the polygon/sector footprint. For larger curvature or strong gradients, numerical geodesic integrations are required (future work).

--- a/examples/example1_orthocenter_reflection_pi_a.py
+++ b/examples/example1_orthocenter_reflection_pi_a.py
@@ -1,0 +1,17 @@
+import math
+from pi_a.core import triangle_angle_sum_pia, is_pia_cyclic
+from pi_a.models import ConstantCurvature, GaussianBump
+
+A, B, C = (0.0, 0.0), (1.2, 0.0), (0.25, 0.9)
+
+# Simplified orthocenter reflection demo: we only check \u03c0\u2090-cyclicity of (A,B,C,H')
+# Here we fabricate an H' near the circumcircle to illustrate flux\u2011balanced behavior.
+Hprime = (0.95, 0.18)
+
+print("Flat case (K=0):")
+K0 = ConstantCurvature(0.0)
+print("  cyclic? ", is_pia_cyclic(A,B,C,Hprime, K0))
+
+print("Curved case (Gaussian bump near center):")
+Kb = GaussianBump(K0=+0.02, x0=0.5, y0=0.35, sigma=0.3)
+print("  cyclic? ", is_pia_cyclic(A,B,C,Hprime, Kb))

--- a/examples/example2_ceva_trig_pia.py
+++ b/examples/example2_ceva_trig_pia.py
@@ -1,0 +1,19 @@
+import math
+from pi_a.core import triangle_angle_sum_pia
+from pi_a.models import ConstantCurvature, GaussianBump
+from pi_a.geometry import angle_at
+
+# This example just prints Euclidean vs \u03c0\u2090 angle sums as a prelude to Ceva-trig forms.
+A, B, C = (0.0, 0.0), (1.0, 0.0), (0.2, 0.8)
+
+K0 = ConstantCurvature(0.0)
+Kb = GaussianBump(K0=0.03, x0=0.4, y0=0.3, sigma=0.35)
+
+S_flat = triangle_angle_sum_pia(A,B,C, K0)
+S_curv = triangle_angle_sum_pia(A,B,C, Kb)
+
+print("Angle sum (flat):   ", S_flat)
+print("Angle sum (curved): ", S_curv, "  (\u0394=", S_curv - S_flat, ")")
+
+# NOTE: Trig\u2011Ceva with explicit flux\u2011correction factor is documented in SPEC; a
+# numerical demo would require explicit cevian split points and sector flux terms.

--- a/examples/example3_gauss_bonnet_triangle.py
+++ b/examples/example3_gauss_bonnet_triangle.py
@@ -1,0 +1,15 @@
+"""Demonstrate Gauss--Bonnet correction for triangle angle sums."""
+import math
+from pi_a.core import triangle_angle_sum_pia
+from pi_a.models import ConstantCurvature
+from pi_a.geometry import tri_area
+
+A, B, C = (0.0, 0.0), (1.0, 0.0), (0.0, 1.0)
+K = ConstantCurvature(0.05)  # constant positive curvature
+
+S = triangle_angle_sum_pia(A, B, C, K)
+expected = math.pi + 0.05 * tri_area(A, B, C)
+
+print("Angle sum with curvature:", S)
+print("Expected (\u03c0 + flux):", expected)
+print("Deviation from flat \u03c0:", S - math.pi)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pi-a-geometry"
+version = "0.1.0"
+description = "Adaptive pi (pi_a) geometry primitives and reference spec"
+readme = "README.md"
+authors = [
+  { name = "Ryan K. Stephens" },
+]
+license = { file = "LICENSE" }
+requires-python = ">=3.9"
+dependencies = [
+  "numpy>=1.24",
+]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-q"

--- a/src/pi_a/__init__.py
+++ b/src/pi_a/__init__.py
@@ -1,0 +1,7 @@
+from .core import (
+    triangle_angle_sum_pia,
+    polygon_angle_sum_pia,
+    sector_flux,
+    is_pia_cyclic,
+)
+from .models import ConstantCurvature, GaussianBump

--- a/src/pi_a/core.py
+++ b/src/pi_a/core.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+import math
+from typing import Tuple, Iterable
+import numpy as np
+from .geometry import tri_area, angle_at, Point
+from .models import CurvatureField
+
+# --- Numerical flux integration helpers ------------------------------------
+
+def polygon_flux(vertices: Iterable[Point], K: CurvatureField, samples: int = 4000) -> float:
+    """Monte\u2011Carlo estimate of \u03a6 = \u222c\u222c_polygon K dA (simple triangle/polygon sampler).
+    For small domains and smooth K, this first\u2011order term is sufficient.
+    """
+    verts = np.array(list(vertices), dtype=float)
+    assert len(verts) >= 3
+    # Triangulate fan at verts[0]
+    base = verts[0]
+    area_total = 0.0
+    flux_total = 0.0
+    rng = np.random.default_rng(12345)
+    for i in range(1, len(verts)-1):
+        A, B, C = base, verts[i], verts[i+1]
+        triA = abs(tri_area(tuple(A), tuple(B), tuple(C)))
+        area_total += triA
+        # sample inside triangle via barycentric
+        n = max(1, samples // (len(verts)-2))
+        u = rng.random(n)
+        v = rng.random(n)
+        mask = u + v > 1.0
+        u[mask] = 1 - u[mask]
+        v[mask] = 1 - v[mask]
+        P = (A + (B-A)[None,:]*u[:,None] + (C-A)[None,:]*v[:,None])
+        Kvals = np.array([K(float(p[0]), float(p[1])) for p in P])
+        flux_total += Kvals.mean() * triA
+    return float(flux_total)
+
+# --- \u03c0\u2090 primitives ----------------------------------------------------------
+
+def triangle_angle_sum_pia(A: Point, B: Point, C: Point, K: CurvatureField) -> float:
+    """S_\u0394 = A+B+C = \u03c0 + \u03a6_\u0394 (first order). Returns the predicted sum in radians."""
+    # Euclidean interior angles
+    angA = angle_at(B, A, C)
+    angB = angle_at(A, B, C)
+    angC = angle_at(A, C, B)
+    # Flux correction
+    Phi = polygon_flux([A,B,C], K)
+    # Replace \u03c0 with \u03c0 + \u03a6_\u0394 - (Euclidean sum - \u03c0)
+    # Equivalently: S_\u0394(\u03c0\u2090) \u2248 (A+B+C) + \u03a6_\u0394  - ( (A+B+C) - \u03c0 ) = \u03c0 + \u03a6_\u0394
+    return math.pi + Phi
+
+def polygon_angle_sum_pia(poly: Iterable[Point], K: CurvatureField) -> float:
+    verts = list(poly)
+    m = len(verts)
+    if m < 3:
+        return 0.0
+    Phi = polygon_flux(verts, K)
+    return (m - 2) * math.pi + Phi
+
+# Sector flux for adaptive inscribed\u2011angle comparisons
+
+def sector_flux(center: Point, P: Point, Q: Point, K: CurvatureField, radius_samples: int = 64, angle_samples: int = 64) -> float:
+    """Approximate flux over a circular sector (center\u2192P\u2192Q) using Euclidean radius
+    as a proxy. For small curvature and small sectors, this is a good first\u2011order proxy.
+    """
+    cx, cy = center
+    rP = math.hypot(P[0]-cx, P[1]-cy)
+    rQ = math.hypot(Q[0]-cx, Q[1]-cy)
+    r = 0.5*(rP + rQ)
+    aP = math.atan2(P[1]-cy, P[0]-cx)
+    aQ = math.atan2(Q[1]-cy, Q[0]-cx)
+    # unwrap angle
+    da = aQ - aP
+    if da <= -math.pi:
+        da += 2*math.pi
+    elif da > math.pi:
+        da -= 2*math.pi
+    # integrate in polar rectangle approx
+    rs = np.linspace(0, r, radius_samples)
+    thetas = np.linspace(aP, aP+da, angle_samples)
+    flux = 0.0
+    for i in range(len(thetas)-1):
+        th = 0.5*(thetas[i]+thetas[i+1])
+        dth = thetas[i+1]-thetas[i]
+        for j in range(len(rs)-1):
+            rr = 0.5*(rs[j]+rs[j+1])
+            dr = rs[j+1]-rs[j]
+            x = cx + rr*math.cos(th)
+            y = cy + rr*math.sin(th)
+            flux += K(x,y) * rr * dth * dr
+    return float(flux)
+
+# \u03c0\u2090-cyclicity: balance of sector fluxes
+
+def is_pia_cyclic(A: Point, B: Point, C: Point, X: Point, K: CurvatureField, center_guess: Point | None = None) -> bool:
+    """Returns True if A,B,C,X are \u03c0\u2090-cyclic to first order: the two inscribed\u2011angle
+    sectors have approximately equal flux so their difference \u2248 0.
+    In flat limit (K=0), this reduces to the Euclidean criterion.
+    """
+    # Heuristic center: circumcenter in Euclidean proxy
+    if center_guess is None:
+        center_guess = _circumcenter_euclid(A,B,C)
+    O = center_guess
+    Phi1 = sector_flux(O, A, B, K)  # sector AB
+    Phi2 = sector_flux(O, A, C, K)  # sector AC
+    return abs(Phi1 - Phi2) < 1e-6  # tolerance can be tuned
+
+# Euclidean circumcenter helper (for center_guess)
+
+def _circumcenter_euclid(A: Point, B: Point, C: Point) -> Point:
+    ax, ay = A; bx, by = B; cx, cy = C
+    d = 2*(ax*(by-cy) + bx*(cy-ay) + cx*(ay-by))
+    if abs(d) < 1e-12:
+        # near-collinear fallback: centroid
+        return ((ax+bx+cx)/3.0, (ay+by+cy)/3.0)
+    a2 = ax*ax + ay*ay
+    b2 = bx*bx + by*by
+    c2 = cx*cx + cy*cy
+    ux = (a2*(by-cy) + b2*(cy-ay) + c2*(ay-by)) / d
+    uy = (a2*(cx-bx) + b2*(ax-cx) + c2*(bx-ax)) / d
+    return (ux, uy)

--- a/src/pi_a/geometry.py
+++ b/src/pi_a/geometry.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+import math
+from typing import Tuple
+
+Point = Tuple[float, float]
+
+def tri_area(A: Point, B: Point, C: Point) -> float:
+    return 0.5 * ((B[0]-A[0])*(C[1]-A[1]) - (B[1]-A[1])*(C[0]-A[0]))
+
+def angle_at(P: Point, Q: Point, R: Point) -> float:
+    """Euclidean interior angle \u2220PQR in radians."""
+    u = (P[0]-Q[0], P[1]-Q[1])
+    v = (R[0]-Q[0], R[1]-Q[1])
+    nu = math.hypot(*u)
+    nv = math.hypot(*v)
+    if nu == 0 or nv == 0:
+        return 0.0
+    dot = (u[0]*v[0] + u[1]*v[1])/(nu*nv)
+    dot = max(-1.0, min(1.0, dot))
+    return math.acos(dot)

--- a/src/pi_a/models.py
+++ b/src/pi_a/models.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+import math
+from typing import Callable
+
+class CurvatureField:
+    def __call__(self, x: float, y: float) -> float:
+        raise NotImplementedError
+
+class ConstantCurvature(CurvatureField):
+    def __init__(self, K: float):
+        self.K = K
+    def __call__(self, x: float, y: float) -> float:
+        return self.K
+
+class GaussianBump(CurvatureField):
+    def __init__(self, K0: float, x0: float, y0: float, sigma: float):
+        self.K0, self.x0, self.y0, self.sigma = K0, x0, y0, sigma
+    def __call__(self, x: float, y: float) -> float:
+        dx, dy = x - self.x0, y - self.y0
+        r2 = (dx*dx + dy*dy)
+        return self.K0 * math.exp(-r2/(2*self.sigma*self.sigma))

--- a/tests/test_ceva_trig_pia.py
+++ b/tests/test_ceva_trig_pia.py
@@ -1,0 +1,10 @@
+from pi_a.core import polygon_angle_sum_pia
+from pi_a.models import ConstantCurvature
+
+square = [(0,0),(1,0),(1,1),(0,1)]
+
+def test_polygon_sum_flat_square():
+    S = polygon_angle_sum_pia(square, ConstantCurvature(0.0))
+    # Sum of interior angles of a square = 2\u03c0
+    import math
+    assert abs(S - 2*math.pi) < 1e-9

--- a/tests/test_cyclicity_balance.py
+++ b/tests/test_cyclicity_balance.py
@@ -1,0 +1,14 @@
+from pi_a.core import is_pia_cyclic
+from pi_a.models import GaussianBump, ConstantCurvature
+
+A, B, C = (0.0,0.0), (1.0,0.0), (0.25,0.9)
+X = (0.9,0.2)
+
+def test_flux_balance_toggle():
+    flat = ConstantCurvature(0.0)
+    curved = GaussianBump(K0=0.05, x0=0.5, y0=0.3, sigma=0.25)
+    # In flat space, sector fluxes are equal (0), so the balance decision is neutral.
+    a = is_pia_cyclic(A,B,C,X, flat)
+    b = is_pia_cyclic(A,B,C,X, curved)
+    assert a in (True, False)
+    assert b in (True, False)

--- a/tests/test_flat_limit.py
+++ b/tests/test_flat_limit.py
@@ -1,0 +1,15 @@
+import math
+from pi_a.core import triangle_angle_sum_pia, is_pia_cyclic
+from pi_a.models import ConstantCurvature
+
+A, B, C, D = (0.0,0.0), (1.0,0.0), (0.3,0.7), (0.9,0.2)
+K0 = ConstantCurvature(0.0)
+
+def test_triangle_sum_flat():
+    S = triangle_angle_sum_pia(A,B,C, K0)
+    assert abs(S - math.pi) < 1e-9
+
+def test_cyclicity_flat_reduces():
+    # With K=0 the \u03c0\u2090-cyclicity reduces to Euclidean: our proxy returns True when fluxes match (here both zero).
+    assert is_pia_cyclic(A,B,C, D, K0) in (True, False)
+    # We only check that it doesn't crash and behaves deterministically in flat case.

--- a/tests/test_triangle_gauss_bonnet.py
+++ b/tests/test_triangle_gauss_bonnet.py
@@ -1,0 +1,12 @@
+import math
+from pi_a.core import triangle_angle_sum_pia
+from pi_a.models import ConstantCurvature
+from pi_a.geometry import tri_area
+
+
+def test_gauss_bonnet_triangle_sum():
+    A, B, C = (0.0, 0.0), (1.0, 0.0), (0.0, 1.0)
+    K = ConstantCurvature(0.05)
+    S = triangle_angle_sum_pia(A, B, C, K)
+    expected = math.pi + 0.05 * tri_area(A, B, C)
+    assert abs(S - expected) < 1e-2


### PR DESCRIPTION
## Summary
- Demonstrate Gauss–Bonnet triangle angle-sum correction with a new example script
- Add test verifying triangle angle sum equals π plus curvature flux
- Bring in project files for core πₐ geometry utilities

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a23cc7aa84832fb48e831473769eaf