### PR TITLE
feat: add inversion and geodesic utilities

### DIFF
--- a/examples/imo/imo_orthocenter_reflection.py
+++ b/examples/imo/imo_orthocenter_reflection.py
@@ -1,10 +1,82 @@
 from pi_a.core import is_pia_cyclic
 from pi_a.models import ConstantCurvature, GaussianBump
+import math
 
-# Triangle with orthocenter H
+# --- Basic helpers ---------------------------------------------------------
+
+def line_through(P, Q):
+    (x1,y1),(x2,y2)=P,Q
+    A = y1 - y2
+    B = x2 - x1
+    C = x1*y2 - x2*y1
+    return (A,B,C)
+
+def intersection(L1, L2):
+    A1,B1,C1=L1; A2,B2,C2=L2
+    D = A1*B2 - A2*B1
+    if abs(D) < 1e-12:
+        raise ValueError("Lines nearly parallel")
+    x = (B1*C2 - B2*C1)/D
+    y = (C1*A2 - C2*A1)/D
+    return (x,y)
+
+def perpendicular_through(L, P):
+    A,B,C = L
+    # Perpendicular to Ax+By+C=0 has direction (A,B) swapped -> (B,-A)
+    # Line with normal (B,-A) through P has eq: B x - A y + C' = 0
+    x0,y0 = P
+    C2 = -(B*x0 - A*y0)
+    return (B, -A, C2)
+
+def reflect_point_across_line(P, L):
+    # Reflect P across line Ax+By+C=0
+    A,B,C = L
+    x0,y0 = P
+    d = (A*x0 + B*y0 + C) / (A*A + B*B)
+    xr = x0 - 2*A*d
+    yr = y0 - 2*B*d
+    return (xr, yr)
+
+# --- Triangle and orthocenter reflection ----------------------------------
 A, B, C = (0.0, 0.0), (2.0, 0.0), (0.5, 1.5)
-# Hardcode an approximate reflection of orthocenter across BC for demo
-Hprime = (0.9, 0.2)
 
-print("Euclidean test (K=0):", is_pia_cyclic(A,B,C, Hprime, ConstantCurvature(0.0)))
-print("πₐ test (Gaussian bump):", is_pia_cyclic(A,B,C, Hprime, GaussianBump(K0=0.02, x0=0.7, y0=0.6, sigma=0.5)))
+# Sides as lines
+BC = line_through(B,C)
+CA = line_through(C,A)
+AB = line_through(A,B)
+
+# Altitudes: through A ⟂ BC, through B ⟂ CA
+altA = perpendicular_through(BC, A)
+altB = perpendicular_through(CA, B)
+
+# Orthocenter H = altA ∩ altB
+H = intersection(altA, altB)
+
+# Reflect H across side BC to H'
+Hprime = reflect_point_across_line(H, BC)
+
+# --- Euclidean verification ------------------------------------------------
+# is_pia_cyclic with K=0 reduces to Euclidean cyclicity check
+print("Euclidean (K=0) cyclicity:", is_pia_cyclic(A,B,C, Hprime, ConstantCurvature(0.0)))
+
+# --- Adaptive-π check (first-order) ----------------------------------------
+Kb = GaussianBump(K0=0.02, x0=0.8, y0=0.4, sigma=0.45)
+print("πₐ (Gaussian bump) cyclicity:", is_pia_cyclic(A,B,C, Hprime, Kb))
+
+# Optional: numeric circumcenter consistency (Euclidean proxy)
+# Compute circumcenter and radius; confirm |OH'|-R ~ 0
+
+def circumcenter(P, Q, R):
+    (ax,ay),(bx,by),(cx,cy)=P,Q,R
+    d = 2*(ax*(by-cy) + bx*(cy-ay) + cx*(ay-by))
+    if abs(d) < 1e-12:
+        return ((ax+bx+cx)/3.0, (ay+by+cy)/3.0), float('nan')
+    a2=ax*ax+ay*ay; b2=bx*bx+by*by; c2=cx*cx+cy*cy
+    ux = (a2*(by-cy) + b2*(cy-ay) + c2*(ay-by))/d
+    uy = (a2*(cx-bx) + b2*(ax-cx) + c2*(bx-ax))/d
+    R = math.hypot(ax-ux, ay-uy)
+    return (ux,uy), R
+
+O,R = circumcenter(A,B,C)
+err = abs(math.hypot(Hprime[0]-O[0], Hprime[1]-O[1]) - R)
+print("Euclidean radius error |OH'|-R:", err)

--- a/examples/imo/imo_power_inversion.py
+++ b/examples/imo/imo_power_inversion.py
@@ -1,0 +1,27 @@
+from pi_a.models import ConstantCurvature, GaussianBump
+from pi_a.core import sector_flux
+import math
+
+# --- Power-of-a-Point under πₐ -------------------------------------------
+
+def power_of_point_pia(P, A, B, C, D, K):
+    """Compute adaptive power of point P wrt circle through A,B,C,D.
+
+    Euclidean version: PA·PB = PC·PD when A,B,C,D concyclic.
+    πₐ version: insert flux-based correction factor.
+    """
+    PA = math.dist(P,A); PB = math.dist(P,B)
+    PC = math.dist(P,C); PD = math.dist(P,D)
+    base = PA*PB - PC*PD
+    # Flux correction: approximate imbalance around P wrt arcs
+    Phi1 = sector_flux(P, A, B, K)
+    Phi2 = sector_flux(P, C, D, K)
+    Xi = 0.5*(Phi1 - Phi2)
+    return base * math.exp(Xi)
+
+# --- Simple demo -----------------------------------------------------------
+A,B,C,D = (0.0,0.0),(2.0,0.0),(1.0,1.732),(1.0,-1.732)
+P = (1.0,0.5)
+
+print("Flat space power:", power_of_point_pia(P,A,B,C,D, ConstantCurvature(0.0)))
+print("Curved space power:", power_of_point_pia(P,A,B,C,D, GaussianBump(0.02,1.0,0.5,0.6)))

--- a/examples/imo/imo_power_of_point.py
+++ b/examples/imo/imo_power_of_point.py
@@ -1,0 +1,14 @@
+from pi_a.inversion import Circle, power_of_point_pia, power_decomposition_pia, invert_point_pia
+from pi_a.models import ConstantCurvature, GaussianBump
+
+C = Circle((0.0, 0.0), 1.0)
+P = (2.0, 0.0)
+
+# Flat case
+base = power_of_point_pia(P, C, ConstantCurvature(0.0))
+print("Euclidean power (should be 3):", base)
+print("Inversion of P across C:", invert_point_pia(P, C, ConstantCurvature(0.0)))
+
+# Curved case (first-order placeholder still near base)
+_, corr = power_decomposition_pia(P, C, GaussianBump(K0=0.02, x0=0.3, y0=0.2, sigma=0.5))
+print("πₐ correction (placeholder, expect ~0 for now):", corr)

--- a/src/pi_a/__init__.py
+++ b/src/pi_a/__init__.py
@@ -6,3 +6,11 @@ from .core import (
 )
 from .models import ConstantCurvature, GaussianBump
 from .ceva import trig_ceva_pia, concurrent_pia
+from .inversion import (
+    Circle,
+    power_of_point_pia,
+    power_decomposition_pia,
+    invert_point_pia,
+)
+from .geodesics import geodesic_circle
+from .circumcurve import circumcurve_pia

--- a/src/pi_a/ceva.py
+++ b/src/pi_a/ceva.py
@@ -25,7 +25,7 @@ def trig_ceva_pia(A: Point, B: Point, C: Point,
                   center_hint: Point | None = None) -> float:
     """Return the trig-Ceva product under πₐ.
 
-    In flat space (K≡⁰), the value equals the Euclidean trig-Ceva product.
+    In flat space (K≡0), the value equals the Euclidean trig-Ceva product.
     With curvature, we optionally multiply by a first-order factor derived from
     sector-flux imbalances at the three vertices.
     """

--- a/src/pi_a/circumcurve.py
+++ b/src/pi_a/circumcurve.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from typing import Tuple
+from .geodesics import geodesic_circle
+from .models import CurvatureField
+import math
+
+Point = Tuple[float, float]
+
+def circumcurve_pia(A: Point, B: Point, C: Point, K: CurvatureField) -> tuple[Point, float]:
+    """Return an adaptive 'circumcurve' center and radius for points A,B,C.
+
+    v0: Euclidean circumcenter/radius (flat-limit exact). Later versions will
+    iteratively nudge the center to balance sector-flux differences.
+    """
+    (ax,ay),(bx,by),(cx,cy) = A,B,C
+    d = 2*(ax*(by-cy) + bx*(cy-ay) + cx*(ay-by))
+    if abs(d) < 1e-12:
+        # Degenerate: return centroid and NaN radius
+        return ((ax+bx+cx)/3.0, (ay+by+cy)/3.0), float('nan')
+    a2=ax*ax+ay*ay; b2=bx*bx+by*by; c2=cx*cx+cy*cy
+    ux = (a2*(by-cy) + b2*(cy-ay) + c2*(ay-by))/d
+    uy = (a2*(cx-bx) + b2*(ax-cx) + c2*(bx-ax))/d
+    R = math.hypot(ax-ux, ay-uy)
+    return (ux,uy), R

--- a/src/pi_a/geodesics.py
+++ b/src/pi_a/geodesics.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+import math
+from typing import Iterable, Tuple, List
+from .models import CurvatureField
+
+Point = Tuple[float, float]
+
+def geodesic_circle(center: Point, r: float, K: CurvatureField, n: int = 256) -> List[Point]:
+    """Return n sample points of a 'geodesic circle' around center with radius r.
+
+    First-order proxy: we return Euclidean samples (flat-limit exact). Future
+    work can warp samples by accumulated curvature along radial geodesics.
+    """
+    cx, cy = center
+    pts = []
+    for i in range(n):
+        th = 2*math.pi * i / n
+        pts.append((cx + r*math.cos(th), cy + r*math.sin(th)))
+    return pts

--- a/src/pi_a/inversion.py
+++ b/src/pi_a/inversion.py
@@ -1,24 +1,51 @@
 from __future__ import annotations
+import math
+from dataclasses import dataclass
 from typing import Tuple
 from .models import CurvatureField
 
+Point = Tuple[float, float]
 
+@dataclass
 class Circle:
-    def __init__(self, O: Tuple[float,float], r: float):
-        self.O, self.r = O, r
+    O: Point
+    r: float
+
+# --- Euclidean baselines ---------------------------------------------------
+
+def power_of_point_euclid(P: Point, C: Circle) -> float:
+    (x,y), (ox,oy) = P, C.O
+    return (x-ox)*(x-ox) + (y-oy)*(y-oy) - C.r*C.r
+
+# --- πₐ helpers ------------------------------------------------------------
+
+def power_decomposition_pia(P: Point, C: Circle, K: CurvatureField) -> tuple[float, float]:
+    """Return (base_euclid_power, first_order_correction).
+
+    For now, we expose the correction as 0.0 (placeholder) while keeping a clean
+    hook for future lens/sector flux. This preserves flat-limit exactness and
+    lets downstream code budget curvature effects explicitly.
+    """
+    base = power_of_point_euclid(P, C)
+    correction = 0.0  # TODO: lens/sector flux across circle chords
+    return base, correction
 
 
-def power_of_point_pia(P, C: Circle, K: CurvatureField) -> float:
-    (x,y), (ox,oy), r = P, C.O, C.r
-    euclid = (x-ox)**2 + (y-oy)**2 - r**2
-    return euclid  # TODO: add flux correction
+def power_of_point_pia(P: Point, C: Circle, K: CurvatureField) -> float:
+    base, corr = power_decomposition_pia(P, C, K)
+    return base + corr
 
 
-def invert_point_pia(P, C: Circle, K: CurvatureField):
-    (x,y), (ox,oy), r2 = P, C.O, C.r**2
+def invert_point_pia(P: Point, C: Circle, K: CurvatureField) -> Point:
+    """Invert point P in circle C. Flat-limit exact; πₐ corrections are higher order.
+
+    Returns the Euclidean inversion, which is the correct zeroth/first-order
+    mapping when curvature effects are modeled separately via power corrections.
+    """
+    (x,y), (ox,oy) = P, C.O
     dx, dy = x-ox, y-oy
     d2 = dx*dx + dy*dy
     if d2 == 0:
-        raise ValueError("Cannot invert center")
-    s = r2 / d2
+        raise ValueError("Cannot invert the center")
+    s = (C.r*C.r) / d2
     return (ox + s*dx, oy + s*dy)

--- a/tests/test_power_inversion_pia.py
+++ b/tests/test_power_inversion_pia.py
@@ -1,15 +1,18 @@
-from pi_a.inversion import Circle, power_of_point_pia, invert_point_pia
-from pi_a.models import ConstantCurvature
+from pi_a.inversion import Circle, power_of_point_pia, power_decomposition_pia, invert_point_pia
+from pi_a.models import ConstantCurvature, GaussianBump
+import math
 
-C = Circle((0,0), 1.0)
-K0 = ConstantCurvature(0.0)
+C = Circle((0.0, 0.0), 1.0)
+P = (2.0, 0.0)
 
-def test_power_center():
-    P = (0.0,0.0)
-    val = power_of_point_pia(P,C,K0)
-    assert abs(val - (-1.0)) < 1e-9
+def test_power_flat():
+    assert abs(power_of_point_pia(P, C, ConstantCurvature(0.0)) - 3.0) < 1e-9
 
-def test_invert_outside():
-    P = (2.0,0.0)
-    Q = invert_point_pia(P,C,K0)
-    assert abs(Q[0]-0.5) < 1e-9
+def test_inversion_flat_roundtrip():
+    Q = invert_point_pia(P, C, ConstantCurvature(0.0))  # should be (0.5, 0.0)
+    assert abs(Q[0] - 0.5) < 1e-9 and abs(Q[1]) < 1e-12
+
+def test_power_correction_placeholder():
+    base, corr = power_decomposition_pia(P, C, GaussianBump(K0=0.02, x0=0.3, y0=0.2, sigma=0.5))
+    assert abs(base - 3.0) < 1e-9
+    assert abs(corr) < 1e-6  # placeholder is ~0


### PR DESCRIPTION
## Summary
- upgrade power-of-a-point and inversion API using dataclasses and flat-limit placeholders
- add geodesic circle sampler and circumcurve helper
- expand examples with orthocenter reflection and power/inversion demos
- include tests for power-of-point and inversion

## Testing
- `PYTHONPATH=src pytest tests/test_power_inversion_pia.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a246c25ae0832fb0a24367e5296f83