### PR TITLE
Add prime-influenced geodesic flow simulator

### DIFF
--- a/docs/riemann-hypothesis/README.md
+++ b/docs/riemann-hypothesis/README.md
@@ -29,10 +29,16 @@ This suggests Riemann zeros emerge from critical symmetry axes in non-Euclidean 
 
 ## Tasks
 
-- [ ] Build a geodesic flow simulator under πₐ perturbations.
-- [ ] Model prime-induced geodesic closures with varying Re(s).
+- [x] Build a geodesic flow simulator under πₐ perturbations.
+- [x] Model prime-induced geodesic closures with varying Re(s).
 - [ ] Determine if closure-lock only happens at Re(s) = 1/2 in curvature field.
 - [ ] Relate oscillations to spacing between zeta zeros.
+
+The new `geodesic_flow` integrator in `pi_a.geodesics` performs a simple
+discrete integration of trajectories in a curvature field and allows a
+"prime forcing" term scaled by the distance of \(\Re(s)\) from the critical
+line. This provides a baseline tool for exploring closure behaviour near
+\(\Re(s)=1/2\).
 
 ---
 

--- a/src/pi_a/__init__.py
+++ b/src/pi_a/__init__.py
@@ -12,3 +12,4 @@ from .miquel import miquel_point_euclid, miquel_point_pia
 from .ninepoint import nine_points, ninepoint_curve_pia
 from .projective import cross_ratio, cross_ratio_pia
 from .cyclic import opposite_angle_sum_pia, is_pia_cyclic_quad
+from .geodesics import geodesic_circle, geodesic_flow

--- a/src/pi_a/geodesics.py
+++ b/src/pi_a/geodesics.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
-from typing import Iterable, Tuple, List
+from typing import Tuple, List
 import math
+
 from .models import CurvatureField
 
-Point = Tuple[float,float]
+Point = Tuple[float, float]
+
 
 def geodesic_circle(O: Point, r: float, K: CurvatureField, n: int = 128) -> List[Point]:
     """Sample a 'geodesic circle' using Euclidean proxy; for small curvature treat as Euclidean circle.
@@ -11,6 +13,67 @@ def geodesic_circle(O: Point, r: float, K: CurvatureField, n: int = 128) -> List
     """
     pts = []
     for i in range(n):
-        th = 2*math.pi * i / n
-        pts.append((O[0] + r*math.cos(th), O[1] + r*math.sin(th)))
+        th = 2 * math.pi * i / n
+        pts.append((O[0] + r * math.cos(th), O[1] + r * math.sin(th)))
+    return pts
+
+
+def _is_prime(n: int) -> bool:
+    """Return ``True`` if *n* is a prime number."""
+    if n < 2:
+        return False
+    for i in range(2, int(math.sqrt(n)) + 1):
+        if n % i == 0:
+            return False
+    return True
+
+
+def geodesic_flow(
+    start: Point,
+    angle: float,
+    K: CurvatureField,
+    steps: int = 100,
+    step: float = 0.1,
+    prime_weight: float = 0.0,
+    re_s: float = 0.5,
+) -> List[Point]:
+    """Integrate a geodesic under a πₐ curvature field.
+
+    Parameters
+    ----------
+    start:
+        Starting point ``(x, y)``.
+    angle:
+        Initial heading in radians.
+    K:
+        Curvature field used to bend the trajectory.
+    steps:
+        Number of integration steps.
+    step:
+        Step size for each integration increment.
+    prime_weight:
+        Extra curvature applied when the step index is prime. The amount is
+        scaled by ``(re_s - 1/2)`` so that the forcing vanishes on the
+        critical line ``Re(s) = 1/2``.
+    re_s:
+        Real part of the zeta argument modelling distance from the critical
+        line.
+
+    Returns
+    -------
+    list[Point]
+        Sampled points along the flow, including the starting point.
+    """
+
+    pts = [start]
+    x, y = start
+    th = angle
+    for i in range(1, steps + 1):
+        k = K(x, y)
+        if prime_weight and _is_prime(i):
+            k += prime_weight * (re_s - 0.5)
+        th += k * step
+        x += step * math.cos(th)
+        y += step * math.sin(th)
+        pts.append((x, y))
     return pts

--- a/tests/test_geodesic_prime_lockin.py
+++ b/tests/test_geodesic_prime_lockin.py
@@ -1,0 +1,42 @@
+import math
+import importlib.util
+import types
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src"
+pkg = types.ModuleType("pi_a")
+pkg.__path__ = [str(_SRC / "pi_a")]
+sys.modules.setdefault("pi_a", pkg)
+
+spec_m = importlib.util.spec_from_file_location("pi_a.models", _SRC / "pi_a" / "models.py")
+models = importlib.util.module_from_spec(spec_m)
+spec_m.loader.exec_module(models)
+sys.modules.setdefault("pi_a.models", models)
+
+spec_g = importlib.util.spec_from_file_location("pi_a.geodesics", _SRC / "pi_a" / "geodesics.py")
+geodesics = importlib.util.module_from_spec(spec_g)
+spec_g.loader.exec_module(geodesics)
+sys.modules.setdefault("pi_a.geodesics", geodesics)
+
+geodesic_flow = geodesics.geodesic_flow
+ConstantCurvature = models.ConstantCurvature
+
+
+def test_prime_lockin_behaviour():
+    steps = 200
+    step = 0.05
+    # curvature chosen so that without prime forcing the path closes
+    K0 = ConstantCurvature(2 * math.pi / (steps * step))
+
+    path = geodesic_flow((0.0, 0.0), 0.0, K0, steps=steps, step=step,
+                         prime_weight=1.0, re_s=0.5)
+    x_end, y_end = path[-1]
+    d1 = math.hypot(x_end, y_end)
+    assert d1 < 0.2
+
+    path2 = geodesic_flow((0.0, 0.0), 0.0, K0, steps=steps, step=step,
+                          prime_weight=1.0, re_s=0.6)
+    x2, y2 = path2[-1]
+    d2 = math.hypot(x2, y2)
+    assert d2 > d1 + 0.2


### PR DESCRIPTION
## Summary
- add `geodesic_flow` integrator with optional prime-based curvature forcing
- expose geodesic helpers in package and document new simulator
- verify prime lock-in behavior with a dedicated test

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pi_a')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*
- `python -m pytest tests/test_geodesic_prime_lockin.py::test_prime_lockin_behaviour -q`

------
https://chatgpt.com/codex/tasks/task_e_68a25761b400832fb3703177d4644dab