### PR TITLE
Add CI workflow and community documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: ${{ matrix.python-version }} }
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e ".[dev]" pytest pytest-cov
+      - run: pytest -q --cov=pi_a --cov-report=xml
+      # - uses: codecov/codecov-action@v4  # optional if you enable Codecov

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+title: Adaptive π Geometry (πₐ)
+version: 0.1.0
+date-released: 2025-08-17
+authors:
+  - family-names: McKenna
+    given-names: Ryan
+  - family-names: Stephens
+    given-names: Ryann Karly
+license: MIT
+repository-code: https://github.com/RDM3DC/Adaptive-PI
+preferred-citation:
+  type: report
+  title: Adaptive π (πₐ) Geometry: Flat-Limit Exactness and First-Order Curvature Corrections
+  authors:
+    - family-names: Stephens
+      given-names: Ryann Karly
+    - family-names: McKenna
+      given-names: Ryan
+  year: 2025

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,18 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Conduct, version 2.1.
+
+## Our Pledge
+We pledge to make participation in our project and community a harassment-free experience for everyone.
+
+## Our Standards
+Examples of behavior that contributes to creating a positive environment include:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting the maintainers via the project repository.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing
+
+1. Fork, create a feature branch, and add tests.
+2. `pip install -e ".[dev]"` then `pytest -q`.
+3. Run `ruff`/`black` (or `pre-commit run -a` if configured).
+4. Open a PR with a concise description and checklist.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # adaptive-pi-geometry
 
+![CI](https://github.com/RDM3DC/Adaptive-PI/actions/workflows/ci.yml/badge.svg)
+![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
+![Python](https://img.shields.io/badge/python-3.10_|_3.11_|_3.12-blue)
+
 A lightweight Python library + reference spec for **Adaptive \u03c0 (\u03c0\u2090)** geometry: a unifying framework that reduces to Euclidean geometry when curvature \u2192 0 and extends gracefully to curved/inhomogeneous settings using first\u2011order Gauss\u2013Bonnet corrections.
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+If you discover a security vulnerability in this project, please report it by opening an issue or contacting the maintainers.
+We will make every effort to respond and address the issue quickly.
+
+Please do not disclose security issues publicly until a fix has been released.


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow for tests on multiple Python versions
- include CITATION, contributing guidelines, code of conduct, and security policy
- display CI, license, and Python version badges in README

## Testing
- `pytest -q` *(fails: No module named 'pi_a' / 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a26f8616b8832fa6cea3733e11b9d3